### PR TITLE
Add SyslogDrainURL and Provider in Instance

### DIFF
--- a/vcaptive.go
+++ b/vcaptive.go
@@ -2,18 +2,20 @@ package vcaptive
 
 import (
 	"encoding/json"
-	"strings"
 	"strconv"
+	"strings"
 )
 
 type Services map[string][]Instance
 
 type Instance struct {
-	Name        string      `json:"name"`
-	Label       string      `json:"label"`
-	Tags        []string    `json:"tags"`
-	Plan        string      `json:"plan"`
-	Credentials Credentials `json:"credentials"`
+	Name           string      `json:"name"`
+	Label          string      `json:"label"`
+	Tags           []string    `json:"tags"`
+	Plan           string      `json:"plan"`
+	Credentials    Credentials `json:"credentials"`
+	Provider       interface{} `json:"provider"`
+	SyslogDrainURL interface{} `json:"syslog_drain_url"`
 }
 
 type Credentials map[string]interface{}


### PR DESCRIPTION
Enable developers to stream applications logs to a syslog compatible aggregation or analytics service that isn’t available in the marketplace.